### PR TITLE
Updates rubocop to ~> 0.23.0

### DIFF
--- a/lib/pronto/rubocop.rb
+++ b/lib/pronto/rubocop.rb
@@ -4,8 +4,8 @@ require 'rubocop'
 module Pronto
   class Rubocop < Runner
     def initialize
-      @inspector = ::Rubocop::FileInspector.new({})
-      @config_store = ::Rubocop::ConfigStore.new
+      @inspector = ::RuboCop::FileInspector.new({})
+      @config_store = ::RuboCop::ConfigStore.new
     end
 
     def run(patches, _)
@@ -18,7 +18,7 @@ module Pronto
     end
 
     def inspect(patch)
-      processed_source = ::Rubocop::SourceParser.parse_file(patch.new_file_full_path)
+      processed_source = ::RuboCop::SourceParser.parse_file(patch.new_file_full_path)
       offences = @inspector.send(:inspect_file, processed_source, @config_store).first
 
       offences.map do |offence|

--- a/pronto-rubocop.gemspec
+++ b/pronto-rubocop.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {spec}/*`.split("\n")
   s.require_paths = ['lib']
 
-  s.add_dependency 'rubocop', '~> 0.20.0'
+  s.add_dependency 'rubocop', '~> 0.23.0'
   s.add_dependency 'pronto', '~> 0.2.0'
   s.add_development_dependency 'rake', '~> 10.1.0'
   s.add_development_dependency 'rspec', '~> 2.14.0'

--- a/spec/pronto/rubocop_spec.rb
+++ b/spec/pronto/rubocop_spec.rb
@@ -21,7 +21,7 @@ module Pronto
     describe '#level' do
       subject { rubocop.level(severity) }
 
-      ::Rubocop::Cop::Severity::NAMES.each do |severity|
+      ::RuboCop::Cop::Severity::NAMES.each do |severity|
         let(:severity) { severity }
         context "severity '#{severity}' conversion to Pronto level" do
           it { should_not be_nil }


### PR DESCRIPTION
This also uses `RuboCop` instead of `Rubocop` which has been changed since 0.23.0: https://github.com/bbatsov/rubocop/commit/ff167d8f202baf7a68955db0aaf0dc29afb7e7ee.
