### PR TITLE
Filter out duplicate Pronto Messages on the same line.

### DIFF
--- a/lib/pronto/rubocop.rb
+++ b/lib/pronto/rubocop.rb
@@ -18,6 +18,14 @@ module Pronto
       end
 
       valid_patches.map { |patch| inspect(patch) }.flatten.compact
+        .each_with_object(Hash.new { |h, k| h[k] = [] } ) { |msg, memo|
+          lineno = msg.line.new_lineno
+          memo[lineno] << msg unless memo[lineno].any? { |existing|
+            existing.msg == msg.msg
+          }
+        }
+        .map { |_,v| v }
+
     end
 
     def inspect(patch)


### PR DESCRIPTION
Hi!

First, thank you for the awesome tool.  Pronto and the associated plugins are very helpful.

I'd like your feedback on this problem I'm having.  The team I'm on is working with a large legacy codebase, and I started using pronto to help guide us towards better code.

However, when a single line contains multiple offenses that are the same, it's unnecessary noise and in an extreme case, causes the github pull request page to fail to load with the angry unicorn (600+ comments can be an effective DOS)

It probably sounds far-fetched, but a large pull request with things like:

``` ruby
 [:multiple,:symbols,:in,:a,:very,:long,:line]
```

will generate the same comment over and over.

This PR is my attempt to remove offenses with the same exact message, per line.

Any feedback appreciated, and thanks again.
