### PR TITLE
Fix for syntax error discarding

### DIFF
--- a/lib/pronto/rubocop.rb
+++ b/lib/pronto/rubocop.rb
@@ -31,11 +31,14 @@ module Pronto
       ruby_file?(path)
     end
 
-    def inspect(patch)
+    def offences(patch)
       processed_source = processed_source_for(patch)
-      offences = @inspector.send(:inspect_file, processed_source).first
 
-      offences.sort.reject(&:disabled?).map do |offence|
+      @inspector.send(:inspect_file, processed_source).first
+    end
+
+    def inspect(patch)
+      offences(patch).sort.reject(&:disabled?).map do |offence|
         patch.added_lines
           .select { |line| line.new_lineno == offence.line }
           .map { |line| new_message(offence, line) }

--- a/lib/pronto/rubocop.rb
+++ b/lib/pronto/rubocop.rb
@@ -39,7 +39,13 @@ module Pronto
         patch.added_lines
           .select { |line| line.new_lineno == offence.line }
           .map { |line| new_message(offence, line) }
-      end
+      end.concat(
+        offences(patch).sort.reject(&:disabled?).select do |offence|
+          offence.cop_name == "Lint/Syntax"
+        end.map do |offence|
+          new_message(offence, patch.added_lines.last)
+        end
+      )
     end
 
     def new_message(offence, line)

--- a/spec/pronto/rubocop_spec.rb
+++ b/spec/pronto/rubocop_spec.rb
@@ -18,6 +18,65 @@ module Pronto
       end
     end
 
+    describe '#inspect' do
+      subject { rubocop.inspect(patches) }
+
+      let(:item_patch) { nil }
+      let(:item_line) { double(new_lineno: 1) }
+      let(:item_offense) { double(disabled?: false, cop_name: "Lint/Syntax", message: "message-text", status: :uncorrected, line: 9) }
+      let(:item_line_patch) { nil }
+      let(:item_delta_value) { nil }
+      let(:item_severity) { double(name: :error) }
+
+      before do
+        allow(rubocop).to receive(:patch).and_return(patch)
+        allow(rubocop).to receive(:offences).and_return(array_of_offences)
+        allow(rubocop).to receive(:patches).and_return(patch)
+
+        allow(item_patch).to receive(:added_lines).and_return(array_of_lines)
+
+        allow(item_line).to receive(:patch).and_return(line_patch)
+        allow(item_line).to receive(:commit_sha).and_return("123456789abcdefgh")
+
+        allow(line_patch).to receive(:delta).and_return(delta_value)
+
+        allow(item_delta_value).to receive(:new_file).and_return(file)
+
+        allow(item_offense).to receive(:severity).and_return(severity)
+
+        allow(item_severity).to receive(:name).and_return(:error)
+      end
+
+      context 'return offences' do
+        let(:patch) { item_patch }
+        let(:line_patch) { item_line_patch }
+        let(:delta_value) { item_delta_value }
+        let(:array_of_offences) { [item_offense] }
+        let(:array_of_lines) { [item_line] }
+        let(:file) { { :path => "file.rb" } }
+        let(:severity) { item_severity }
+
+        it 'syntax error offense' do
+          should == [[], Message.new("file.rb", patch.added_lines.last, :error, "message-text", nil, nil)]
+        end
+      end
+
+      context 'does not return offences' do
+        let(:item_offense) { double(disabled?: false, cop_name: "Asd", message: "message-text", status: :uncorrected, line: 1) }
+        let(:patch) { item_patch }
+        let(:line_patch) { item_line_patch }
+        let(:delta_value) { item_delta_value }
+        let(:array_of_offences) { [item_offense] }
+        let(:array_of_lines) { [item_line] }
+        let(:file) { { :path => "file.rb" } }
+        let(:severity) { item_severity }
+
+        it 'syntax error offense' do
+          should == [[Message.new("file.rb", patch.added_lines.last, :error, "message-text", nil, nil)]]
+        end
+      end
+    end
+
     describe '#level' do
       subject { rubocop.level(severity) }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,5 +4,4 @@ require 'pronto/rubocop'
 
 RSpec.configure do |config|
   config.expect_with(:rspec) { |c| c.syntax = :should }
-  config.mock_with(:rspec) { |c| c.syntax = :should }
 end


### PR DESCRIPTION
**The result of pronto-rubocop does not include syntactic errors.**

Missing syntactic error in the result of pronto-rubocop was solved by mapping this error on the last element of the patch.

File containing syntax error:

```ruby
while a < 15
	(
print a, " "
    if a == 10 then
        prin"made it to ten!!"

    a = a + 1
end
```

Variable `offences`'s value in method `inspect(patch)` in file `lib/pronto/rubocop.rb`:
https://github.com/prontolabs/pronto-rubocop/blob/master/lib/pronto/rubocop.rb#L38
```
[42] pry(#<Pronto::Rubocop>)> offences
=> [#<RuboCop::Cop::Offense:0x0000564daa700d20
  @cop_name="Lint/Syntax",
  @location=#<Parser::Source::Range /root/miq_bot/testrepo/error.rb 99...99>,
  @message=
   "unexpected token $end\n(Using Ruby 2.3 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)",
  @severity=#<RuboCop::Cop::Severity:0x0000564daa7014f0 @name=:error>,
  @status=:uncorrected>]
```

**before**:

The syntactic error is missing in the result of the rubocop.

```
[168] pry(#<Pronto::Rubocop>)> offences.sort.reject(&:disabled?).map do |offence|
[168] pry(#<Pronto::Rubocop>)*   patch.added_lines        
[168] pry(#<Pronto::Rubocop>)*   .select { |line| line.new_lineno == offence.line }          
[168] pry(#<Pronto::Rubocop>)*   .map { |line| new_message(offence, line) }          
[168] pry(#<Pronto::Rubocop>)* end        
=> [[]]
```

**after**:

The syntactic error message is assigned to the **last** element of patch variable.

```
[174] pry(#<Pronto::Rubocop>)> offences.sort.reject(&:disabled?).map do |offence|
[174] pry(#<Pronto::Rubocop>)*   patch.added_lines        
[174] pry(#<Pronto::Rubocop>)*   .select { |line| line.new_lineno == offence.line }          
[174] pry(#<Pronto::Rubocop>)*   .map { |line| new_message(offence, line) }          
[174] pry(#<Pronto::Rubocop>)* end.concat(        
[174] pry(#<Pronto::Rubocop>)*   offences.sort.reject(&:disabled?).select do |offence|        
[174] pry(#<Pronto::Rubocop>)*     offence.cop_name == "Lint/Syntax"          
[174] pry(#<Pronto::Rubocop>)*   end.map do |offence|          
[174] pry(#<Pronto::Rubocop>)*     new_message(offence, patch.added_lines.last)          
[174] pry(#<Pronto::Rubocop>)*   end          
[174] pry(#<Pronto::Rubocop>)* )        
=> [[],
 #<Pronto::Message:0x0000564da7503070
  @commit_sha="dfa09b8920c8932aa0454dcffb93966fc1c9b2f5",
  @level=:error,
  @line=
   #<struct Pronto::Git::Line
    line=
     #<Rugged::Diff::Line:47445775201620 {line_origin: :addition, content: "end\n">,
    patch=
     #<struct Pronto::Git::Patch
      patch=#<Rugged::Patch:47445789709400>,
      repo=
       #<Pronto::Git::Repository:0x0000564daae22db0
        @repo=
         #<Rugged::Repository:47445789710020 {path: "/root/miq_bot/testrepo/.git/"}>>>,
    hunk=
     #<Rugged::Diff::Hunk:47445775202180 {header: "@@ -0,0 +1,8 @@\n", count: 8}>>,
  @msg=
   "unexpected token $end\n(Using Ruby 2.3 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)",
  @path="error.rb",
  @runner=Pronto::Rubocop>]
```

### Informations (version, platform, engine)
```
[175] pry(#<Pronto::Rubocop>)> RUBY_VERSION
=> "2.3.1"
[176] pry(#<Pronto::Rubocop>)> RUBY_PLATFORM
=> "x86_64-linux-gnu"
[177] pry(#<Pronto::Rubocop>)> RUBY_ENGINE
=> "ruby"
[178] pry(#<Pronto::Rubocop>)> Pronto::RubocopVersion::VERSION
=> "0.9.0"
[179] pry(#<Pronto::Rubocop>)> ::RuboCop::Version.version
=> "0.52.1"
```

/cc
@skateman
@romanblanco