### PR TITLE
Support RuboCop v0.85.0 and later

### DIFF
--- a/lib/pronto/rubocop/offense_line.rb
+++ b/lib/pronto/rubocop/offense_line.rb
@@ -56,12 +56,23 @@ module Pronto
       end
 
       def autocorrect_team
-        @autocorrect_team ||= ::RuboCop::Cop::Team.new(
-          ::RuboCop::Cop::Registry.new([cop]),
-          patch_cop.rubocop_config,
-          auto_correct: true,
-          stdin: true,
-        )
+        @autocorrect_team ||=
+          if ::RuboCop::Cop::Team.respond_to?(:mobilize)
+            # rubocop v0.85.0 and later
+            ::RuboCop::Cop::Team.mobilize(
+              ::RuboCop::Cop::Registry.new([cop]),
+              patch_cop.rubocop_config,
+              auto_correct: true,
+              stdin: true,
+            )
+          else
+            ::RuboCop::Cop::Team.new(
+              ::RuboCop::Cop::Registry.new([cop]),
+              patch_cop.rubocop_config,
+              auto_correct: true,
+              stdin: true,
+            )
+          end
       end
 
       def cop

--- a/lib/pronto/rubocop/patch_cop.rb
+++ b/lib/pronto/rubocop/patch_cop.rb
@@ -60,7 +60,13 @@ module Pronto
       end
 
       def team
-        @team ||= ::RuboCop::Cop::Team.new(registry, rubocop_config)
+        @team ||=
+          if ::RuboCop::Cop::Team.respond_to?(:mobilize)
+            # rubocop v0.85.0 and later
+            ::RuboCop::Cop::Team.mobilize(registry, rubocop_config)
+          else
+            ::RuboCop::Cop::Team.new(registry, rubocop_config)
+          end
       end
     end
   end


### PR DESCRIPTION
I changed to use `Rubocop::Cop::Team#mobilize` instead of `Rubocop::Cop::Team.new` if RuboCop version is 0.85.0 and later because RuboCop changed `Team` API at v0.85.0.
ref. https://github.com/rubocop-hq/rubocop/pull/8030