### PR TITLE
Change to require rubocop 1.0.0 or above

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['2.4', '2.5', '2.6', '2.7', '3.0']
-        rubocop: ['0.63.1', '0.84.0', '0.85.0', '0.86.0', '0.87.0', '< 1.0']
+        rubocop: ['0.63.1', '0.81.0', '0.84.0', '0.85.0', '0.86.0', '0.87.0', '< 1.0', '1.0.0', '< 2.0']
         include:
           - ruby: '2.3'
             rubocop: '0.63.1'
@@ -24,7 +24,7 @@ jobs:
     - name: use specific rubocop version
       run: echo "gem 'rubocop', '${{ matrix.rubocop }}'" > Gemfile.local
     - name: use specific rubocop-ast version (if required)
-      if: matrix.rubocop == '0.84.0' || matrix.rubocop == '0.85.0' || matrix.rubocop == '0.85.1'
+      if: matrix.rubocop == '0.84.0' || matrix.rubocop == '0.85.0'
       run: echo "gem 'rubocop-ast', '< 0.7.0'" >> Gemfile.local
     - uses: ruby/setup-ruby@v1
       with:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,3 +13,8 @@ Layout/MultilineOperationIndentation:
 
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
+
+Metrics/BlockLength:
+  Exclude:
+    - pronto-rubocop.gemspec
+    - spec/**/*_spec.rb

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,6 @@
 #!/usr/bin/env rake
+# frozen_string_literal: true
+
 require 'bundler'
 require 'rspec/core/rake_task'
 

--- a/lib/pronto/rubocop.rb
+++ b/lib/pronto/rubocop.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pronto'
 require 'rubocop'
 require 'pronto/rubocop/patch_cop'
@@ -7,7 +9,7 @@ module Pronto
   class Rubocop < Runner
     def run
       ruby_patches
-        .select { |patch| patch.additions > 0 }
+        .select { |patch| patch.additions.positive? }
         .flat_map { |patch| PatchCop.new(patch, self).messages }
     end
 

--- a/lib/pronto/rubocop/offense_line.rb
+++ b/lib/pronto/rubocop/offense_line.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Pronto
   class Rubocop < Runner
     class OffenseLine
@@ -31,7 +33,7 @@ module Pronto
 
       def suggestion_text
         return unless patch_cop.runner.pronto_rubocop_config['suggestions']
-        return if corrections_count == 0
+        return if corrections_count.zero?
         return if differing_lines_count != corrections_count
 
         @suggestion_text ||= corrected_lines[offense.line - 1]
@@ -87,11 +89,10 @@ module Pronto
       def autocorrect_team
         @autocorrect_team ||=
           ::RuboCop::Cop::Team.send(MOBILIZE,
-            ::RuboCop::Cop::Registry.new([cop_class]),
-            patch_cop.rubocop_config,
-            auto_correct: true,
-            stdin: true,
-          )
+                                    ::RuboCop::Cop::Registry.new([cop_class]),
+                                    patch_cop.rubocop_config,
+                                    auto_correct: true,
+                                    stdin: true)
       end
 
       def cop_class

--- a/lib/pronto/rubocop/patch_cop.rb
+++ b/lib/pronto/rubocop/patch_cop.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Pronto
   class Rubocop < Runner
     class PatchCop

--- a/lib/pronto/rubocop/version.rb
+++ b/lib/pronto/rubocop/version.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module Pronto
   module RubocopVersion
-    VERSION = '0.11.0'.freeze
+    VERSION = '0.11.0'
   end
 end

--- a/pronto-rubocop.gemspec
+++ b/pronto-rubocop.gemspec
@@ -1,6 +1,6 @@
-# -*- encoding: utf-8 -*-
+# frozen_string_literal: true
 
-$LOAD_PATH.push File.expand_path('../lib', __FILE__)
+$LOAD_PATH.push File.expand_path('lib', __dir__)
 require 'pronto/rubocop/version'
 require 'English'
 

--- a/pronto-rubocop.gemspec
+++ b/pronto-rubocop.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('pronto', '~> 0.11.0')
   s.add_runtime_dependency('rubocop', '>= 0.63.1', '< 2.0')
+  s.add_development_dependency('appraisal')
   s.add_development_dependency('rake', '~> 12.0')
   s.add_development_dependency('rspec', '~> 3.4')
   s.add_development_dependency('rspec-its', '~> 1.2')

--- a/pronto-rubocop.gemspec
+++ b/pronto-rubocop.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_runtime_dependency('pronto', '~> 0.11.0')
-  s.add_runtime_dependency('rubocop', '>= 0.63.1', '< 1.0')
+  s.add_runtime_dependency('rubocop', '>= 0.63.1', '< 2.0')
   s.add_development_dependency('rake', '~> 12.0')
   s.add_development_dependency('rspec', '~> 3.4')
   s.add_development_dependency('rspec-its', '~> 1.2')

--- a/spec/pronto/rubocop/offense_line_spec.rb
+++ b/spec/pronto/rubocop/offense_line_spec.rb
@@ -52,13 +52,8 @@ describe Pronto::Rubocop::OffenseLine do
     context 'with overridden severity levels to "fatal"' do
       let(:config) do
         {
-          'severities' => {
-            'refactor' => 'fatal',
-            'convention' => 'fatal',
-            'warning' => 'fatal',
-            'error' => 'fatal',
-            'fatal' => 'fatal'
-          }
+          'severities' =>
+            Hash[::RuboCop::Cop::Severity::NAMES.map { |name| [name, 'fatal'] }] 
         }
       end
 

--- a/spec/pronto/rubocop/offense_line_spec.rb
+++ b/spec/pronto/rubocop/offense_line_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Pronto::Rubocop::OffenseLine do
@@ -29,7 +31,7 @@ describe Pronto::Rubocop::OffenseLine do
     it { expect(message.msg).to eq('Fake message') }
 
     context 'with default severity levels' do
-       default_level_hash = {
+      default_level_hash = {
         refactor: :warning,
         convention: :warning,
         warning: :warning,
@@ -55,8 +57,8 @@ describe Pronto::Rubocop::OffenseLine do
             'convention' => 'fatal',
             'warning' => 'fatal',
             'error' => 'fatal',
-            'fatal' => 'fatal',
-          },
+            'fatal' => 'fatal'
+          }
         }
       end
 

--- a/spec/pronto/rubocop/patch_cop_spec.rb
+++ b/spec/pronto/rubocop/patch_cop_spec.rb
@@ -9,7 +9,8 @@ describe Pronto::Rubocop::PatchCop do
   end
   let(:line) { double :line, new_lineno: 42 }
   let(:runner) { double :runner }
-  let(:processed_source) { double :processed_source }
+  let(:ast) { double :ast, each_node: nil }
+  let(:processed_source) { double :processed_source, ast: ast }
   let(:team) { double :team, inspect_file: [offense] }
   let(:offense) { double :offense, disabled?: false, line: 42 }
   let(:offense_line) { double :offense_line, message: 'Err' }

--- a/spec/pronto/rubocop/patch_cop_spec.rb
+++ b/spec/pronto/rubocop/patch_cop_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Pronto::Rubocop::PatchCop do

--- a/spec/pronto/rubocop_spec.rb
+++ b/spec/pronto/rubocop_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module Pronto

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rspec'
 require 'rspec/its'
 require 'pronto/rubocop'


### PR DESCRIPTION
This PR changes version requirement of rubocop gem to 1.0.0 or above.
~~It also changes version requirement of ruby to 2.4.0 or above because of rubocop's ruby requirement.~~