### PR TITLE
fix compatibility with RuboCop 1.3.0 and later

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
   NewCops: enable
+  TargetRubyVersion: 2.4 # workaround for https://github.com/rubocop-hq/rubocop/issues/9482 as gemspec has 2.3.0
 
 Style/Documentation:
   Enabled: false


### PR DESCRIPTION
As a result of https://github.com/rubocop-hq/rubocop/issues/8761 the TargetRubyVersion is read from the gemspec and due to a bug (https://github.com/rubocop-hq/rubocop/issues/9482) this blocks the upgrade to support later RuboCop versions -- so let's specify 2.4 as a workaround.