### PR TITLE
Fix Style/HashConversion by rubocop.

### DIFF
--- a/spec/pronto/rubocop/offense_line_spec.rb
+++ b/spec/pronto/rubocop/offense_line_spec.rb
@@ -53,7 +53,7 @@ describe Pronto::Rubocop::OffenseLine do
       let(:config) do
         {
           'severities' =>
-            Hash[::RuboCop::Cop::Severity::NAMES.map { |name| [name, 'fatal'] }] 
+            ::RuboCop::Cop::Severity::NAMES.map { |name| [name, 'fatal'] }.to_h
         }
       end
 


### PR DESCRIPTION
The following code was pointed out by Rubocop.

```
spec/pronto/rubocop/offense_line_spec.rb:56:13: C: [Correctable] Style/HashConversion: Prefer ary.to_h to Hash[ary].
            Hash[::RuboCop::Cop::Severity::NAMES.map { |name| [name, 'fatal'] }] 
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Therefore, we fixed the code.
Could you please approve this PR?