### PR TITLE
Fix for RUBOCOP_CONFIG environment variable

### DIFF
--- a/lib/pronto/rubocop/patch_cop.rb
+++ b/lib/pronto/rubocop/patch_cop.rb
@@ -35,6 +35,7 @@ module Pronto
       def rubocop_config
         @rubocop_config ||= begin
           store = ::RuboCop::ConfigStore.new
+          store.options_config = ENV['RUBOCOP_CONFIG'] if ENV['RUBOCOP_CONFIG']
           store.for(path)
         end
       end


### PR DESCRIPTION
This PR is a proposal to fix https://github.com/prontolabs/pronto-rubocop/issues/67

It looks like the use of `RUBOCOP_CONFIG` was removed in this commit: [https://github.com/prontolabs/pronto-rubocop/pull/44/files#diff-f8a1b8209086b10d50565dc2776339d453c4bd8783d3c1dfb28907fcad85a125L37](https://github.com/prontolabs/pronto-rubocop/pull/44/files#diff-f8a1b8209086b10d50565dc2776339d453c4bd8783d3c1dfb28907fcad85a125L37)

However, the README still mentions that `RUBOCOP_CONFIG` is supported.