### PR TITLE
Fixes #73: Add Info Severity

### DIFF
--- a/lib/pronto/rubocop/offense_line.rb
+++ b/lib/pronto/rubocop/offense_line.rb
@@ -118,6 +118,7 @@ module Pronto
       end
 
       DEFAULT_SEVERITIES = {
+        info: :info,
         refactor: :warning,
         convention: :warning,
         warning: :warning,


### PR DESCRIPTION
Fixes #73

See https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Severity and https://github.com/rubocop/rubocop/pull/9391 for documentation on `info` severity