### PR TITLE
update PatchCop to support spanning errors

### DIFF
--- a/spec/pronto/rubocop/patch_cop_spec.rb
+++ b/spec/pronto/rubocop/patch_cop_spec.rb
@@ -12,7 +12,8 @@ describe Pronto::Rubocop::PatchCop do
   let(:ast) { double :ast, each_node: nil }
   let(:processed_source) { double :processed_source, ast: ast }
   let(:team) { double :team, inspect_file: [offense] }
-  let(:offense) { double :offense, disabled?: false, line: 42 }
+  let(:offense_location) { double :location, first_line: 42, last_line: 43 }
+  let(:offense) { double :offense, disabled?: false, location: offense_location }
   let(:offense_line) { double :offense_line, message: 'Err' }
 
   before do
@@ -30,6 +31,14 @@ describe Pronto::Rubocop::PatchCop do
   describe '#messages' do
     it do
       expect(patch_cop.messages).to eq(['Err'])
+    end
+
+    context 'when there is an error including the patch, but not starting inside it' do
+      let(:offense_location) { double :location, first_line: 40, last_line: 43 }
+
+      it do
+        expect(patch_cop.messages).to eq(['Err'])
+      end
     end
   end
 end


### PR DESCRIPTION
# Purpose
Currently, if a changeset appends a bunch of logic to a large method, and the resulting method is "too complex", rubocop will complain, but pronto-rubocop will not notice. This is because we're comparing the `offense.line` against the patch to see if that line is part of the changes being checked.. but the `offense.line` is actually `offense.location.first_line`, which can be _outside_ the changes, despite the violation being introduced.

# Implementation
* Update PatchCop to look for the the lines where the offense-range _includes_ the changed line
* Switch from `select` to `detect` - the prior implementation only ever hit a given offense once, since it only traversed each line-number once. But now it's possible (likely) to hit the same offense multiple times on consecutive lines, and we're only interested in the _first_ time the offense was affected.
* Add a test to cover the new case in `patch_cop_spec.rb`.