### PR TITLE
Revert "Fix for RUBOCOP_CONFIG environment variable"

### DIFF
--- a/lib/pronto/rubocop/patch_cop.rb
+++ b/lib/pronto/rubocop/patch_cop.rb
@@ -40,7 +40,6 @@ module Pronto
       def rubocop_config
         @rubocop_config ||= begin
           store = ::RuboCop::ConfigStore.new
-          store.options_config = ENV['RUBOCOP_CONFIG'] if ENV['RUBOCOP_CONFIG']
           store.for(path)
         end
       end


### PR DESCRIPTION
Reverts prontolabs/pronto-rubocop#72