### PR TITLE
fix crash with RuboCop >= 1.41.0 when there are no corrections

### DIFF
--- a/lib/pronto/rubocop/offense_line.rb
+++ b/lib/pronto/rubocop/offense_line.rb
@@ -34,6 +34,7 @@ module Pronto
       def suggestion_text
         return unless patch_cop.runner.pronto_rubocop_config['suggestions']
         return if corrections_count.zero?
+        return if corrector.nil?  # possible after optimisation in https://github.com/rubocop/rubocop/pull/11264
         return if differing_lines_count != corrections_count
 
         @suggestion_text ||= corrected_lines[offense.line - 1]


### PR DESCRIPTION
https://github.com/rubocop/rubocop/pull/11264 did optimisations to not set `RuboCop::Cop::Base::InvestigationReport#corrector` when there are no corrections.

fixes #83