### PR TITLE
Re-respect rubocop files config

### DIFF
--- a/lib/pronto/rubocop.rb
+++ b/lib/pronto/rubocop.rb
@@ -8,7 +8,9 @@ require 'pronto/rubocop/offense_line'
 module Pronto
   class Rubocop < Runner
     def run
-      ruby_patches
+      return [] unless @patches
+
+      @patches
         .select { |patch| patch.additions.positive? }
         .flat_map { |patch| PatchCop.new(patch, self).messages }
     end

--- a/lib/pronto/rubocop/patch_cop.rb
+++ b/lib/pronto/rubocop/patch_cop.rb
@@ -50,7 +50,7 @@ module Pronto
         return false if rubocop_config.file_to_exclude?(path)
         return true if rubocop_config.file_to_include?(path)
 
-        true
+        runner.ruby_file?(path)
       end
 
       def path


### PR DESCRIPTION
This PR https://github.com/prontolabs/pronto-rubocop/pull/36 basically reverts changes from this PR https://github.com/prontolabs/pronto-rubocop/pull/16 "Process files included in .rubocop.yml"

It happen because starting from https://github.com/prontolabs/pronto-rubocop/pull/36/files#diff-bd66c995e7650e0ca147e089eb3732f7a0b7bb0de38733f83e97485254285317R7 it passes down `ruby_patches` from Pronto's runner instead of the whole `@patches`, so it again ignores the files configured in `.rubocop.yml`. In our case, it ignores `.jbuilder` extensions