### PR TITLE
Fix Rubocop deprecated method warnings

### DIFF
--- a/lib/pronto/rubocop/patch_cop.rb
+++ b/lib/pronto/rubocop/patch_cop.rb
@@ -31,7 +31,10 @@ module Pronto
       end
 
       def registry
-        @registry ||= ::RuboCop::Cop::Registry.new(RuboCop::Cop::Cop.all)
+        @registry ||= ::RuboCop::Cop::Registry.new(
+          # keep support of older Rubocop versions
+          RuboCop::Cop.const_defined?(:Registry) ? RuboCop::Cop::Registry.all : RuboCop::Cop::Cop.all
+        )
       end
 
       def rubocop_config
@@ -58,8 +61,14 @@ module Pronto
       end
 
       def offenses
-        team
-          .inspect_file(processed_source)
+        # keep support of older Rubocop versions
+        if team.respond_to?(:investigate)
+          offenses = team.investigate(processed_source).offenses
+        else
+          offenses = team.inspect_file(processed_source)
+        end
+
+        offenses
           .sort
           .reject(&:disabled?)
       end

--- a/lib/pronto/rubocop/patch_cop.rb
+++ b/lib/pronto/rubocop/patch_cop.rb
@@ -33,7 +33,11 @@ module Pronto
       def registry
         @registry ||= ::RuboCop::Cop::Registry.new(
           # keep support of older Rubocop versions
-          RuboCop::Cop.const_defined?(:Registry) ? RuboCop::Cop::Registry.all : RuboCop::Cop::Cop.all
+          if RuboCop::Cop.const_defined?(:Registry) && RuboCop::Cop::Registry.respond_to?(:all)
+            RuboCop::Cop::Registry.all
+          else
+            RuboCop::Cop::Cop.all
+          end
         )
       end
 

--- a/lib/pronto/rubocop/patch_cop.rb
+++ b/lib/pronto/rubocop/patch_cop.rb
@@ -31,14 +31,7 @@ module Pronto
       end
 
       def registry
-        @registry ||= ::RuboCop::Cop::Registry.new(
-          # keep support of older Rubocop versions
-          if RuboCop::Cop.const_defined?(:Registry) && RuboCop::Cop::Registry.respond_to?(:all)
-            RuboCop::Cop::Registry.all
-          else
-            RuboCop::Cop::Cop.all
-          end
-        )
+        @registry ||= ::RuboCop::Cop::Registry.new(all_cops)
       end
 
       def rubocop_config
@@ -52,6 +45,15 @@ module Pronto
       private
 
       attr_reader :patch
+
+      def all_cops
+        # keep support of older Rubocop versions
+        if RuboCop::Cop.const_defined?(:Registry) && RuboCop::Cop::Registry.respond_to?(:all)
+          RuboCop::Cop::Registry.all
+        else
+          RuboCop::Cop::Cop.all
+        end
+      end
 
       def valid?
         return false if rubocop_config.file_to_exclude?(path)

--- a/spec/pronto/rubocop/patch_cop_spec.rb
+++ b/spec/pronto/rubocop/patch_cop_spec.rb
@@ -11,7 +11,8 @@ describe Pronto::Rubocop::PatchCop do
   let(:runner) { double :runner }
   let(:ast) { double :ast, each_node: nil }
   let(:processed_source) { double :processed_source, ast: ast }
-  let(:team) { double :team, inspect_file: [offense] }
+  let(:team) { double :team, investigate: offenses }
+  let(:offenses) { double :offenses, offenses: [offense] }
   let(:offense_location) { double :location, first_line: 42, last_line: 43 }
   let(:offense) { double :offense, disabled?: false, location: offense_location }
   let(:offense_line) { double :offense_line, message: 'Err' }


### PR DESCRIPTION
Fix Rubocop deprecated method warnings:

* pronto-rubocop-0.11.5/lib/pronto/rubocop/patch_cop.rb:34: warning: `Cop.all` is deprecated. Use `Registry.all` instead.
* pronto-rubocop-0.11.5/lib/pronto/rubocop/patch_cop.rb:62: warning: `inspect_file` is deprecated. Use `investigate` instead.