### PR TITLE
Fixes #92 - Changes Pronto::Rubocop::OffenseLine to use investigate if it is available

### DIFF
--- a/lib/pronto/rubocop/offense_line.rb
+++ b/lib/pronto/rubocop/offense_line.rb
@@ -79,7 +79,7 @@ module Pronto
 
         def corrector
           @corrector ||= begin
-            autocorrect_team.inspect_file(processed_source)
+            autocorrect_team.investigate(processed_source)
             corrector = RuboCop::Cop::Corrector.new(processed_source.buffer)
             corrector.corrections.concat(autocorrect_team.cops.first.corrections)
             corrector

--- a/lib/pronto/rubocop/offense_line.rb
+++ b/lib/pronto/rubocop/offense_line.rb
@@ -79,7 +79,11 @@ module Pronto
 
         def corrector
           @corrector ||= begin
-            autocorrect_team.investigate(processed_source)
+            if autocorrect_team.respond_to?(:investigate)
+              autocorrect_team.investigate(processed_source)
+            else
+              autocorrect_team.inspect_file(processed_source)
+            end
             corrector = RuboCop::Cop::Corrector.new(processed_source.buffer)
             corrector.corrections.concat(autocorrect_team.cops.first.corrections)
             corrector

--- a/lib/pronto/rubocop/offense_line.rb
+++ b/lib/pronto/rubocop/offense_line.rb
@@ -79,14 +79,19 @@ module Pronto
 
         def corrector
           @corrector ||= begin
-            if autocorrect_team.respond_to?(:investigate)
-              autocorrect_team.investigate(processed_source)
-            else
-              autocorrect_team.inspect_file(processed_source)
-            end
+            investigate(autocorrect_team)
             corrector = RuboCop::Cop::Corrector.new(processed_source.buffer)
             corrector.corrections.concat(autocorrect_team.cops.first.corrections)
             corrector
+          end
+        end
+
+        def investigate(autocorrect_team)
+          # keep support of older Rubocop versions
+          if autocorrect_team.respond_to?(:investigate)
+            autocorrect_team.investigate(processed_source)
+          else
+            autocorrect_team.inspect_file(processed_source)
           end
         end
 

--- a/lib/pronto/rubocop/patch_cop.rb
+++ b/lib/pronto/rubocop/patch_cop.rb
@@ -71,7 +71,7 @@ module Pronto
         if team.respond_to?(:investigate)
           offenses = team.investigate(processed_source).offenses
         else
-          offenses = team.inspect_file(processed_source)
+          offenses = team.investigate(processed_source)
         end
 
         offenses

--- a/lib/pronto/rubocop/patch_cop.rb
+++ b/lib/pronto/rubocop/patch_cop.rb
@@ -71,7 +71,7 @@ module Pronto
         if team.respond_to?(:investigate)
           offenses = team.investigate(processed_source).offenses
         else
-          offenses = team.investigate(processed_source)
+          offenses = team.inspect_file(processed_source)
         end
 
         offenses


### PR DESCRIPTION
As reported in #92 when using the `inspect_file` method in the `Pronto::Rubocop::OffenseLine` class, it causes a deprecation warning along the lines of

```
/Users/user/.rvm/gems/ruby-3.3.2@airtasker/gems/pronto-rubocop-0.11.5/lib/pronto/rubocop/patch_cop.rb:34: warning: `Cop.all` is deprecated. Use `Registry.all` instead.
/Users/user/.rvm/gems/ruby-3.3.2@airtasker/gems/pronto-rubocop-0.11.5/lib/pronto/rubocop/patch_cop.rb:62: warning: `inspect_file` is deprecated. Use `investigate` instead.
```



There is only 2 uses of inspect_file in the codebase and one is already wrapped in a responds_to? conditional that tries investigate if the version of Rubocop supports it [here](https://github.com/prontolabs/pronto-rubocop/blob/bc22f3585ec8506a3473e824a1f8ea91cdd1d424/lib/pronto/rubocop/patch_cop.rb#L71)

The other is in [offense_line.rb](https://github.com/prontolabs/pronto-rubocop/blob/bc22f3585ec8506a3473e824a1f8ea91cdd1d424/lib/pronto/rubocop/offense_line.rb#L81) and does not have this conditional check.

This is an attempt to fix it.